### PR TITLE
Wrapping the call to the Menu model get() in a try catch.

### DIFF
--- a/menu/templatetags/menubuilder.py
+++ b/menu/templatetags/menubuilder.py
@@ -68,7 +68,10 @@ def get_items(menu_name, current_path, user):
     else:
         menuitems = []
         
-    menu = Menu.objects.get(slug=menu_name)
+    try:
+        menu = Menu.objects.get(slug=menu_name)
+    except Menu.DoesNotExist:
+        return []
 
     for i in MenuItem.objects.filter(menu=menu).order_by('order'):
         current = ( i.link_url != '/' and current_path.startswith(i.link_url)) or ( i.link_url == '/' and current_path == '/' )


### PR DESCRIPTION
This isn't a major issue - more of a gripe.

When setting up versions of sites that use a menu, any templates that attempt to load a menu will throw DoesNotExist exception. This just bypasses that exception by returning [] so that we can get a site up and running and leave the managers to create and build menus.

Hope that makes sense.
