### PR TITLE
Update Menu.save() method to pass *args and **kwargs argument. The curre...

### DIFF
--- a/menu/models.py
+++ b/menu/models.py
@@ -32,14 +32,14 @@ class Menu(models.Model):
     def __unicode__(self):
         return u"%s" % self.name
 
-    def save(self, force_insert=False, force_update=False):
+    def save(self, *args, **kwargs):
         """
         Re-order all items from 10 upwards, at intervals of 10.
-        This makes it easy to insert new items in the middle of 
-        existing items without having to manually shuffle 
+        This makes it easy to insert new items in the middle of
+        existing items without having to manually shuffle
         them all around.
         """
-        super(Menu, self).save(force_insert, force_update)
+        super(Menu, self).save(*args, **kwargs)
 
         current = 10
         for item in MenuItem.objects.filter(menu=self).order_by('order'):


### PR DESCRIPTION
...nt

implementation explicitly lists force_insert and force_update only. Considering
the full list of kwargs save() expects includes 'using' and 'update_fields',
this is problematic if these kwargs need to be specified when saving a new Menu
object. For example, when create a new Menu with factory-boy, the user is
presented with the following error: "TypeError: save() got an unexpected
keyword argument 'using'". Since the current implementation uses the default
values for force_insert and force_update anyway, simply passing _args and
*_kwargs is an acceptable way to fulfill the underlying API contract.
