### PR TITLE
Fix ugettext_lazy deprecation

### DIFF
--- a/menu/apps.py
+++ b/menu/apps.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
+
 from django.apps import AppConfig as BaseConfig
 
 
 class AppConfig(BaseConfig):
     name = 'menu'
     verbose_name = _('Menu')
+

--- a/menu/models.py
+++ b/menu/models.py
@@ -1,4 +1,8 @@
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
+
 from django.db import models
 
 


### PR DESCRIPTION
ugettext_lazy was already [deprecated](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0) and is removed in Django 4.0.

If it can not be imported, use gettext_lazy instead, which should
be an alias at least since 3.0.

To err on the safe side with even older versions, ugettext_lazy is
still tried first.